### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,4 +1,4 @@
-project boost/doc ;
+project lambda/doc ;
 import boostbook : boostbook ;
 
 # Are these really the correct images??


### PR DESCRIPTION
There can be only one project named boost/doc - and we already have that under doc/
This fixes the PDF doc build.
