### PR TITLE
Update return_type_traits.hpp

### DIFF
--- a/include/boost/lambda/detail/return_type_traits.hpp
+++ b/include/boost/lambda/detail/return_type_traits.hpp
@@ -13,6 +13,7 @@
 #define BOOST_LAMBDA_RETURN_TYPE_TRAITS_HPP
 
 #include "boost/mpl/has_xxx.hpp"
+#include <boost/type_traits/ice.hpp>
 
 #include <cstddef> // needed for the ptrdiff_t
 


### PR DESCRIPTION
This header should include the type_traits hedaers it needs and not depend on implicit inclusion which will go away in the current type_traits rewrite.