### PR TITLE
Update operator_return_type_traits.hpp

### DIFF
--- a/include/boost/lambda/detail/operator_return_type_traits.hpp
+++ b/include/boost/lambda/detail/operator_return_type_traits.hpp
@@ -12,7 +12,13 @@
 #define BOOST_LAMBDA_OPERATOR_RETURN_TYPE_TRAITS_HPP
 
 #include "boost/lambda/detail/is_instance_of.hpp"
-#include "boost/type_traits/same_traits.hpp"
+#include "boost/type_traits/is_same.hpp"
+#include "boost/type_traits/is_pointer.hpp"
+#include "boost/type_traits/is_float.hpp"
+#include "boost/type_traits/is_convertible.hpp"
+#include "boost/type_traits/remove_pointer.hpp"
+#include "boost/type_traits/remove_const.hpp"
+#include "boost/type_traits/remove_reference.hpp"
 
 #include "boost/indirect_reference.hpp"
 #include "boost/detail/container_fwd.hpp"


### PR DESCRIPTION
This file needs to include the type_traits headers it actually uses - problem exposed by ongoing type traits rewrite.