### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/include/boost/lambda/detail/suppress_unused.hpp
+++ b/include/boost/lambda/detail/suppress_unused.hpp
@@ -10,8 +10,8 @@
 
 // ------------------------------------------------------------
 
-#ifndef BOOST_LAMBDA_SUPRESS_UNUSED_HPP
-#define BOOST_LAMBDA_SUPRESS_UNUSED_HPP
+#ifndef BOOST_LAMBDA_SUPPRESS_UNUSED_HPP
+#define BOOST_LAMBDA_SUPPRESS_UNUSED_HPP
 
 namespace boost { 
 namespace lambda {


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.