### PR TITLE
Remove mentions of deprecated macros

### DIFF
--- a/include/boost/lambda/detail/lambda_functors.hpp
+++ b/include/boost/lambda/detail/lambda_functors.hpp
@@ -300,7 +300,7 @@ public:
 
 namespace boost {
 
-#if !defined(BOOST_RESULT_OF_USE_DECLTYPE) || defined(BOOST_NO_DECLTYPE)
+#if !defined(BOOST_RESULT_OF_USE_DECLTYPE) || defined(BOOST_NO_CXX11_DECLTYPE)
 
 template<class T>
 struct result_of<boost::lambda::lambda_functor<T>()>


### PR DESCRIPTION
The configuration macro `BOOST_NO_DECLTYPE` was deprecated in Boost 1.51.0, and replaced by `BOOST_NO_CXX11_DECLTYPE`. Use the new macro name.

No functionality change.
