### PR TITLE
Only support std::random_shuffle when available

### DIFF
--- a/include/boost/lambda/algorithm.hpp
+++ b/include/boost/lambda/algorithm.hpp
@@ -684,6 +684,8 @@ struct rotate_copy {
 
 // random_shuffle  ---------------------------------
 
+#ifndef BOOST_NO_CXX98_RANDOM_SHUFFLE
+
 struct random_shuffle {
 
   template <class Args>
@@ -703,6 +705,7 @@ struct random_shuffle {
 
 };
 
+#endif
 
 // partition  ---------------------------------
 


### PR DESCRIPTION
It was removed in C++17. We could emulate it when it isn't available,
but that doesn't seem worth the effort.