### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -18,15 +18,13 @@ constant boost_dependencies :
     /boost/utility//boost_utility ;
 
 project /boost/lambda
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_lambda : : : : <library>$(boost_dependencies) ]
+    [ alias boost_lambda : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_lambda test ]
     ;
 
 call-if : boost-library lambda
     ;
-

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,29 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/lambda
+    : common-requirements
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/tuple//boost_tuple
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_lambda ]
+    [ alias all : boost_lambda test ]
+    ;
+
+call-if : boost-library lambda
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,16 +7,16 @@ import project ;
 
 project /boost/lambda
     : common-requirements
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/tuple//boost_tuple
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/tuple//boost_tuple
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/lambda

--- a/build.jam
+++ b/build.jam
@@ -5,25 +5,28 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/bind//boost_bind
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/iterator//boost_iterator
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/tuple//boost_tuple
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/lambda
     : common-requirements
-        <library>/boost/bind//boost_bind
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/tuple//boost_tuple
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_lambda ]
+    [ alias boost_lambda : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_lambda test ]
     ;
 
 call-if : boost-library lambda
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/lambda
     : common-requirements

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,17 +1,17 @@
 # Lambda library
 
-# Copyright (C) 2001-2003 Jaakko Järvi
+# Copyright (C) 2001-2003 Jaakko Jï¿½rvi
 
-# Use, modification and distribution is subject to the Boost Software License, 
-# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at 
-# http://www.boost.org/LICENSE_1_0.txt) 
+# Use, modification and distribution is subject to the Boost Software License,
+# Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
 
 # For more information, see http://www.boost.org/
 
 import testing ;
 
 run algorithm_test.cpp ;
-run bind_tests_advanced.cpp : : : <source>/boost/any//boost_any ;
+run bind_tests_advanced.cpp : : : <library>/boost/any//boost_any ;
 run bind_tests_simple.cpp ;
 run bind_tests_simple_f_refs.cpp ;
 run bll_and_function.cpp ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -10,6 +10,8 @@
 
 import testing ;
 
+project : requirements <library>/boost/lambda//boost_lambda ;
+
 run algorithm_test.cpp ;
 run bind_tests_advanced.cpp : : : <library>/boost/any//boost_any ;
 run bind_tests_simple.cpp ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,7 +11,7 @@
 import testing ;
 
 run algorithm_test.cpp ;
-run bind_tests_advanced.cpp ;
+run bind_tests_advanced.cpp : : : <source>/boost/any//boost_any ;
 run bind_tests_simple.cpp ;
 run bind_tests_simple_f_refs.cpp ;
 run bll_and_function.cpp ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.